### PR TITLE
Change the temperature OID

### DIFF
--- a/check_akcp_sensorprobe.pl
+++ b/check_akcp_sensorprobe.pl
@@ -5,7 +5,7 @@
 
 =head1 COPYRIGHT
 
- 
+
 This software is Copyright (c) 2010 NETWAYS GmbH, Thomas Gelf
                                <support@netways.de>
 
@@ -247,7 +247,7 @@ sub checkTempSensor {
 
     my %result = fetchOids({
 	    $oid . '.1.1.'  . $id  => 'description',  # Sensor name / description
-	    $oid . '.1.14.' . $id  => 'degree',	      # Currently measured degree
+	    $oid . '.1.3.' . $id  => 'degree',	      # Currently measured degree
 	    $oid . '.1.4.'  . $id  => 'status',	      # Sensor status, see %status_map
 	    $oid . '.1.7.'  . $id  => 'highWarning',  # Configured upper warning threshold
 	    $oid . '.1.8.'  . $id  => 'highCritical', # Configured upper critical threshold
@@ -267,7 +267,7 @@ sub checkTempSensor {
 	    '%s Temperature sensor "%s": %.2f%s (%.1f:%.1f/%.1f:%.1f)',
         $status_map{$result{'status'}},
         $result{'description'},
-        $result{'degree'} / 10,
+        $result{'degree'},
         $degree_map{$result{'degreeType'}},
         $result{'lowWarning'},
         $result{'highWarning'},

--- a/check_akcp_sensorprobe.pl
+++ b/check_akcp_sensorprobe.pl
@@ -5,7 +5,7 @@
 
 =head1 COPYRIGHT
 
- 
+
 This software is Copyright (c) 2010 NETWAYS GmbH, Thomas Gelf
                                <support@netways.de>
 
@@ -247,7 +247,7 @@ sub checkTempSensor {
 
     my %result = fetchOids({
 	    $oid . '.1.1.'  . $id  => 'description',  # Sensor name / description
-	    $oid . '.1.14.' . $id  => 'degree',	      # Currently measured degree
+	    $oid . '.1.3.' . $id  => 'degree',	      # Currently measured degree
 	    $oid . '.1.4.'  . $id  => 'status',	      # Sensor status, see %status_map
 	    $oid . '.1.7.'  . $id  => 'highWarning',  # Configured upper warning threshold
 	    $oid . '.1.8.'  . $id  => 'highCritical', # Configured upper critical threshold
@@ -257,7 +257,7 @@ sub checkTempSensor {
     });
     $performance{sanitize($result{'description'})} = sprintf(
 	    "%.2f;%.1f:%.1f;%.1f:%.1f",
-        $result{'degree'} / 10,
+        $result{'degree'},
         $result{'lowWarning'},
         $result{'highWarning'},
         $result{'lowCritical'},
@@ -267,7 +267,7 @@ sub checkTempSensor {
 	    '%s Temperature sensor "%s": %.2f%s (%.1f:%.1f/%.1f:%.1f)',
         $status_map{$result{'status'}},
         $result{'description'},
-        $result{'degree'} / 10,
+        $result{'degree'},
         $degree_map{$result{'degreeType'}},
         $result{'lowWarning'},
         $result{'highWarning'},


### PR DESCRIPTION
Because AKCP does not serve the old one anymore on newer sensorProbes. The new OID must
not be divided by 10 as it is already degree. Tested with 7 AKCP sensorProbe2 with
different firmwares. Fixes #3